### PR TITLE
Update zip_open.c

### DIFF
--- a/codes/0/libzip-1.8.0/lib/zip_open.c
+++ b/codes/0/libzip-1.8.0/lib/zip_open.c
@@ -477,7 +477,7 @@ _zip_checkcons(zip_t *za, zip_cdir_t *cd, zip_error_t *error) {
         _zip_dirent_finalize(&temp);
     }
 
-    return 0
+    return (max - min) < ZIP_INT64_MAX ? (zip_int64_t)(max - min) : ZIP_INT64_MAX;
 }
 
 


### PR DESCRIPTION
Adding back in an integer overflow vuln in codes/0/libzip-1.8.0/lib/zip_open.c at line 480